### PR TITLE
Adding sudo to coreos-install command as default user core is not cap…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ end
 ### Install and configure provisioner node
 ```bash
 $ echo 1 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
-$ coreos-installer install /dev/sda --ignition-url=https://bit.ly/oibl-ignition
+$ sudo coreos-installer install /dev/sda --ignition-url=https://bit.ly/oibl-ignition
 $ sudo systemctl reboot
 $ ssh kni@<IP> (Enter `Kni@123` as password)
 $ sudo rpm-ostree rebase --experimental \


### PR DESCRIPTION
…able to run it.

In my test with FCOS with the commands I see sudo was missing which results to "Error: getting sector size of /dev/sda

Caused by:
        0: Opening "/dev/sda"
        1: Permission denied (os_error 13)